### PR TITLE
FIX: Tell the request we're anonymous for CORS purposes

### DIFF
--- a/favcount.js
+++ b/favcount.js
@@ -20,6 +20,8 @@
         img  = document.createElement('img');
 
     if (self.canvas.getContext) {
+      img.crossOrigin = "anonymous";
+
       img.onload = function() {
         drawCanvas(self.canvas, self.opacity, self.font, img, normalize(count));
       };


### PR DESCRIPTION
I added CORS to our ico files to allow for cross domain usage (I develop on localhost and our ico is on our production server). However, I was still getting security errors until I added this `crossDomain` attribute.

I got the tip from:
http://stackoverflow.com/questions/20062076/webgl-cors-an-attempt-was-made-to-break-through-the-security-policy-of-the-user

When I use this, the errors go away! 
