### PR TITLE
Check for existence of link element in HTML

### DIFF
--- a/favcount.js
+++ b/favcount.js
@@ -90,7 +90,9 @@
 
     // Replace favicon with new favicon
     favicon.href = canvas.toDataURL('image/png');
-    head.removeChild(document.querySelector('link[rel=icon]'));
+    if (document.querySelector('link[rel=icon]') {
+      head.removeChild(document.querySelector('link[rel=icon]'));
+    }
     head.appendChild(favicon);
   }
 


### PR DESCRIPTION
If you don't do this, you'll get an error if the code is run on a page without a favicon in the HTML. Remember that you don't actually have to include a favicon in your HTML, the browser will automatically pull in favicon.ico in the root of the domain, by default. So you should always check before doing the removeChild action.
